### PR TITLE
Make GCS bucket configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ENV FLASK_APP=main.py
 ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_RUN_PORT=8080
 ENV PYTHONUNBUFFERED=1
+# Default bucket; override at runtime if needed
+ENV GCS_BUCKET=debiflow-staging
 
 # Expose the port for Cloud Run
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# DebiFlow
+
+DebiFlow is a Flask-based application for managing loan repayment data using Google Cloud Storage.
+
+## Configuration
+
+Set the GCS bucket name via the `GCS_BUCKET` environment variable. If unset, the app defaults to `debiflow-staging`.
+
+```
+export GCS_BUCKET=my-debiflow-bucket
+```
+
+## Running in Codespaces
+
+Install dependencies and start the server:
+
+```
+pip install -r requirements.txt
+flask run --host=0.0.0.0 --port=8080
+```
+
+## Docker
+
+The Dockerfile sets `GCS_BUCKET` to `debiflow-staging` by default. Build and run the container, overriding the variable if needed:
+
+```
+docker build -t debiflow .
+docker run -p 8080:8080 -e GCS_BUCKET=my-debiflow-bucket debiflow
+```

--- a/download_all_gcs_files.py
+++ b/download_all_gcs_files.py
@@ -1,7 +1,7 @@
 import os
 from scripts.debiflow_gcs import DebiFlowGCS
 
-BUCKET_NAME = "debiflow-staging"
+BUCKET_NAME = os.getenv("GCS_BUCKET", "debiflow-staging")
 DOWNLOAD_FOLDER = "downloads"
 PREFIXES = [
     "raw/Schedule_", "raw/Payments_", "raw/CustomerDetails_", "raw/HP_Repayments_",

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ from scripts.utils import build_investor_path, require_investor
 
 # Config
 ALLOWED_PREFIXES = ['HP_Repayments_', 'CustomerDetails_', 'Schedule_', 'Payments_']
-GCS_BUCKET = "debiflow-staging"#<<<<<<<<<<This is where you can change the bucket
+GCS_BUCKET = os.getenv("GCS_BUCKET", "debiflow-staging")
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24)

--- a/scripts/download_all_gcs_files.py
+++ b/scripts/download_all_gcs_files.py
@@ -2,7 +2,7 @@ import os
 import sys
 from scripts.debiflow_gcs import DebiFlowGCS
 
-BUCKET_NAME = "debiflow-staging"
+BUCKET_NAME = os.getenv("GCS_BUCKET", "debiflow-staging")
 DOWNLOAD_FOLDER = "downloads"
 FILE_TYPES = ["Schedule", "Payments", "CustomerDetails", "HP_Repayments"]
 

--- a/scripts/file_tracker.py
+++ b/scripts/file_tracker.py
@@ -7,7 +7,7 @@ import os
 REQUIRED_PREFIXES = ["Payments_", "Schedule_", "CustomerDetails_", "HP_Repayments_"]
 RAW_FOLDER       = "raw/"
 MASTER_FOLDER    = "master/"
-DEFAULT_BUCKET   = "debiflow-staging"
+DEFAULT_BUCKET   = os.getenv("GCS_BUCKET", "debiflow-staging")
 
 def get_reporting_dates(bucket_name: str = DEFAULT_BUCKET,
                         reference_date: str = None,

--- a/scripts/list_master_blobs.py
+++ b/scripts/list_master_blobs.py
@@ -1,7 +1,8 @@
 import sys
+import os
 from google.cloud import storage
 
-def list_master_blobs(investor, bucket_name="debiflow-staging"):
+def list_master_blobs(investor, bucket_name=os.getenv("GCS_BUCKET", "debiflow-staging")):
     prefix = f"master/{investor}/"
     client = storage.Client()
     bucket = client.bucket(bucket_name)

--- a/scripts/list_raw_files.py
+++ b/scripts/list_raw_files.py
@@ -1,7 +1,8 @@
 import sys
+import os
 from google.cloud import storage
 
-BUCKET_NAME = "debiflow-staging"
+BUCKET_NAME = os.getenv("GCS_BUCKET", "debiflow-staging")
 
 def list_uploaded_files(investor):
     prefix = f"raw/{investor}/"


### PR DESCRIPTION
## Summary
- allow configuring the storage bucket via `GCS_BUCKET` env var
- update helper scripts to use the env var
- document the variable in README
- set a default in the Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a2d88add48321866a92b129c8a357