### PR TITLE
Add SQLAlchemy models and login

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,24 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+
+# Initialize SQLAlchemy without app; app will call init_app
+
+db = SQLAlchemy()
+
+# Association table for many-to-many between users and companies
+user_companies = db.Table(
+    'user_companies',
+    db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True),
+    db.Column('company_id', db.Integer, db.ForeignKey('company.id'), primary_key=True)
+)
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    companies = db.relationship('Company', secondary=user_companies, backref='users')
+
+class Company(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), unique=True, nullable=False)
+    bucket_name = db.Column(db.String(120), nullable=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ certifi==2025.6.15
 charset-normalizer==3.4.2
 click==8.1.8
 Flask==3.1.1
+Flask-Login==0.6.3
+Flask-SQLAlchemy==3.1.1
 google-api-core==2.25.1
 google-auth==2.40.3
 google-cloud-core==2.4.3

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,5 +1,6 @@
 from functools import wraps
-from flask import request, redirect, flash
+from flask import request, redirect, flash, g
+from models import Company, db
 
 def build_investor_path(investor, subfolder, filename):
     """
@@ -18,5 +19,10 @@ def require_investor(f):
             flash("❌ No investor selected.")
             return redirect("/")
         kwargs['investor'] = investor
+        company = Company.query.filter_by(name=investor).first()
+        if company:
+            g.company_bucket = company.bucket_name
+        else:
+            g.company_bucket = None
         return f(*args, **kwargs)
     return decorated_function

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h2>Login</h2>
+    <form method="post">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+    <p><a href="{{ url_for('signup') }}">Sign Up</a></p>
+</body>
+</html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Sign Up</title>
+</head>
+<body>
+    <h2>Sign Up</h2>
+    <form method="post">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <input type="text" name="company" placeholder="Company Name" required>
+        <input type="text" name="bucket_name" placeholder="GCS Bucket" required>
+        <button type="submit">Create Account</button>
+    </form>
+    <p><a href="{{ url_for('login') }}">Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for `User` and `Company`
- integrate Flask-Login and Flask-SQLAlchemy in `main.py`
- look up bucket from database with updated `require_investor`
- add login and signup templates
- document new dependencies

## Testing
- `python -m py_compile models.py main.py scripts/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686a36baa74483219084af9fed4a6e3e